### PR TITLE
Fix invalid XML etc

### DIFF
--- a/hastebin.xml
+++ b/hastebin.xml
@@ -7,7 +7,7 @@
   <MyIP>192.168.1.20</MyIP>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
-  <Support/>https://forums.unraid.net/topic/103384-support-flippinturt-hastebin</support>
+  <Support/>https://forums.unraid.net/topic/103384-support-flippinturt-hastebin</Support>
   <Project>https://github.com/nzzane/haste-server</Project>
   <Overview>Alpine-based Docker image for Hastebin, the node.js paste service  &#xD;
 Haste is an open-source pastebin software written in node.js, which is easily installable in any network. &#xD;


### PR DESCRIPTION
Also, not quite sure what you're trying to do with the extra volume.  If it's a mistake, then you need to delete that volume you added.  If it's supposed to be there, then it needs to be another <Volume> section, not within the existing one, and you would also need a new <Config> for the added path.  How you've done it will have the feed trigger a fatal error, since it's not correct.